### PR TITLE
default.nix: add flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+(
+  import
+    (
+      builtins.fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+        sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+      }
+    ) {
+    src = ./.;
+  }).defaultNix


### PR DESCRIPTION
Now people who don't use flakes will be able to use the packages.