### PR TITLE
Add winestreamproxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         package:
         - discord-ipc-bridge
         - wine-osu
+        - winestreamproxy
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: cachix/install-nix-action@v13

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,8 @@
         };
 
         wine-osu = prev.callPackage ./pkgs/wine-osu {};
+
+        winestreamproxy = prev.callPackage ./pkgs/winestreamproxy { wine = nixpkgs.legacyPackages.x86_64-linux.wineWowPackages.minimal; };
       };
     in
       # only x86 linux is supported by wine
@@ -41,7 +43,7 @@
             };
 
             apps.osu-stable = utils.lib.mkApp { drv = packages.osu-stable; };
-            packages = { inherit (pkgs) discord-ipc-bridge osu-stable wine-osu; };
+            packages = { inherit (pkgs) discord-ipc-bridge osu-stable wine-osu winestreamproxy; };
           in
             {
               inherit apps packages;

--- a/pkgs/winestreamproxy/default.nix
+++ b/pkgs/winestreamproxy/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, wine
+}:
+
+stdenv.mkDerivation rec {
+  pname = "winestreamproxy";
+  version = "unstable-2020-10-17";
+
+  src = fetchFromGitHub {
+    owner = "openglfreak";
+    repo = pname;
+    rev = "075622872bbff0621791296137edb616af680297";
+    sha256 = "sha256-I579RJ9iBREYnqEiEgFXWbPSatbVv0cjMHloK2l5D6Q=";
+  };
+
+  nativeBuildInputs = [ pkg-config wine ];
+
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = {
+    description = "Program for Wine that forwards messages between a named pipe client and a unix socket server";
+    homepage = "https://github.com/openglfreak/winestreamproxy";
+    maintainers = with lib.maintainers; [ fufexan ];
+    platforms = with lib.platforms; [ "i686-linux" "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
It's a replacement for discord-ipc-bridge, which doesn't work anymore on wine 6.11+, since a wine call which it relied on has been removed.
This should also greatly reduce the size of `osu-stable` as it compiles using winegcc instead of pkgsCross.