### PR TITLE
Improve documentation, set saner default for quant

### DIFF
--- a/modules/pipewireLowLatency.nix
+++ b/modules/pipewireLowLatency.nix
@@ -13,8 +13,8 @@ in
       quantum = lib.mkOption {
         description = "Minimum quantum to set";
         type = lib.types.int;
-        default = 32;
-        example = 48;
+        default = 64;
+        example = 32;
       };
       rate = lib.mkOption {
         description = "Rate to set";


### PR DESCRIPTION
Based on the input of a few users, I decided to raise the quant to 64, as the difference in latency is too small to be perceptible.

Updated documentation to make it easier for people not using flakes to use this repo.