### PR TITLE
Fix OSU installation dir

### DIFF
--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -51,7 +51,7 @@ let
       # install osu
       wine ${osusrc}
       wineserver -k
-      mv "$WINEPREFIX/drive_c/users/$USER/Local Settings/Application Data/osu!" $WINEPREFIX/drive_c/osu
+      mv "$WINEPREFIX/drive_c/users/$USER/AppData/Local/osu!" $WINEPREFIX/drive_c/osu
     fi
 
     winestreamproxy -f &


### PR DESCRIPTION
By default, osu installs in `AppData/Local/osu!` instead of `Local Settings/Application Data/osu!`.