### PR TITLE
flake-utils -> flake-utils-plus

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,21 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1626019149,
@@ -92,17 +107,21 @@
       }
     },
     "utils": {
+      "inputs": {
+        "flake-utils": "flake-utils"
+      },
       "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "lastModified": 1626816926,
+        "narHash": "sha256-mJKFdfc4UWL49ar2Tc4krKMnDUa0Dkhj8QmbR3SThHo=",
+        "owner": "gytis-ivaskevicius",
+        "repo": "flake-utils-plus",
+        "rev": "5dba7556e1c7f36152c9f65c16bc813ec73ee6a5",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "gytis-ivaskevicius",
+        "ref": "staging",
+        "repo": "flake-utils-plus",
         "type": "github"
       }
     }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,0 +1,27 @@
+{ inputs }:
+final: prev: {
+  osu-stable = prev.callPackage ./osu-stable {
+    wine = final.wine-tkg;
+    winetricks = prev.winetricks.override { wine = final.wine-tkg; };
+    inherit (final) winestreamproxy;
+  };
+
+  winestreamproxy = prev.callPackage ./winestreamproxy { wine = final.wine-tkg; };
+
+  wine-tkg = prev.callPackage ./wine-tkg {
+    wine =
+      if prev.system == "x86_64-linux"
+      then final.wineWowPackages.unstable
+      else final.wineUnstable;
+    inherit (inputs) tkgPatches oglfPatches;
+  };
+
+  # --- deprecated ---
+  discord-ipc-bridge = prev.pkgsCross.mingw32.callPackage ./discord-ipc-bridge { dib = inputs.discord-ipc-bridge; };
+
+  wine-osu =
+    let
+      nwo = inputs.nixpkgs-wine-osu.legacyPackages.${prev.system};
+    in
+    nwo.callPackage ./wine-osu { wine = nwo.wineUnstable; };
+}


### PR DESCRIPTION
Use [flake-utils-plus](https://github.com/gytis-ivaskevicius/flake-utils-plus/tree/staging) instead of `flake-utils` for:
* automatic `overlays.*` generation
* automatic packaging for respective platforms defined in `meta.platforms`, respecting `supportedSystems`
* nice `exportModules` function that lets you easily add modules from paths

With this occasion I also moved `overlay` to `pkgs/default.nix` to declutter the flake.